### PR TITLE
Changing the zoom from a set value to a multiplier

### DIFF
--- a/src/main/java/com/logicalgeekboy/logical_zoom/LogicalZoom.java
+++ b/src/main/java/com/logicalgeekboy/logical_zoom/LogicalZoom.java
@@ -15,7 +15,7 @@ public class LogicalZoom implements ClientModInitializer {
     private static boolean originalSmoothCameraEnabled;
     private static final MinecraftClient mc = MinecraftClient.getInstance();
 
-    public static final double zoomLevel = 19.0;
+    public static final double zoomLevel = 0.271428571429;
 
     @Override
     public void onInitializeClient() {

--- a/src/main/java/com/logicalgeekboy/logical_zoom/mixin/LogicalZoomMixin.java
+++ b/src/main/java/com/logicalgeekboy/logical_zoom/mixin/LogicalZoomMixin.java
@@ -16,10 +16,11 @@ import net.minecraft.client.render.GameRenderer;
 @Mixin(GameRenderer.class)
 public class LogicalZoomMixin {
 
-    @Inject(method = "getFov(Lnet/minecraft/client/render/Camera;FZ)D", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "getFov(Lnet/minecraft/client/render/Camera;FZ)D", at = @At("RETURN"), cancellable = true)
     public void getZoomLevel(CallbackInfoReturnable<Double> callbackInfo) {
         if(LogicalZoom.isZooming()) {
-            callbackInfo.setReturnValue(LogicalZoom.zoomLevel);
+            double fov = callbackInfo.getReturnValue();
+            callbackInfo.setReturnValue(fov*LogicalZoom.zoomLevel);
         }
         
         LogicalZoom.manageSmoothCamera();


### PR DESCRIPTION
There is an open issue that calls attention to the fact the the spyglass does not stack the zoom from this mod.
By changing the 'zoomLevel' variable to be a less than one and changing the return value of the getFov method to multiply by this number solves this.

I chose the value "0.271428571429" because it is roughly equal to 19/70, 19 being the original 'zoomLevel' and 70 being the default FOV of minecraft.

Built & tested on my machine and ran with no crashes or bugs.