### PR TITLE
Tweak zoom level and bump to 0.0.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.17+build.1
 loader_version=0.11.3
 
 # Mod Properties
-mod_version = 0.0.9
+mod_version = 0.0.10
 maven_group = com.logicalgeekboy.logical_zoom
 archives_base_name = logical_zoom
 

--- a/src/main/java/com/logicalgeekboy/logical_zoom/LogicalZoom.java
+++ b/src/main/java/com/logicalgeekboy/logical_zoom/LogicalZoom.java
@@ -15,7 +15,7 @@ public class LogicalZoom implements ClientModInitializer {
     private static boolean originalSmoothCameraEnabled;
     private static final MinecraftClient mc = MinecraftClient.getInstance();
 
-    public static final double zoomLevel = 0.271428571429;
+    public static final double zoomLevel = 0.23;
 
     @Override
     public void onInitializeClient() {

--- a/src/main/java/com/logicalgeekboy/logical_zoom/mixin/LogicalZoomMixin.java
+++ b/src/main/java/com/logicalgeekboy/logical_zoom/mixin/LogicalZoomMixin.java
@@ -20,9 +20,9 @@ public class LogicalZoomMixin {
     public void getZoomLevel(CallbackInfoReturnable<Double> callbackInfo) {
         if(LogicalZoom.isZooming()) {
             double fov = callbackInfo.getReturnValue();
-            callbackInfo.setReturnValue(fov*LogicalZoom.zoomLevel);
+            callbackInfo.setReturnValue(fov * LogicalZoom.zoomLevel);
         }
-        
+
         LogicalZoom.manageSmoothCamera();
     }
 }


### PR DESCRIPTION
After some testing of the spyglass compatibility I felt the zoom level was a little out when in F5 mode facing the camera. Comparing to the original look, I've tweaked the zoom level to match.

Also bumped the version to 0.0.10