### PR TITLE
Support Minecraft 1.18

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Java 16
+    - name: Set up Java 17
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt-hotspot'
-        java-version: '16'
+        distribution: 'temurin'
+        java-version: '17'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.10-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -26,9 +26,6 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-
-	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
-	// You may need to force-disable transitiveness on them.
 }
 
 processResources {
@@ -40,14 +37,8 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// ensure that the encoding is set to UTF-8, no matter what the system default is
-	// this fixes some edge cases with special characters not displaying correctly
-	// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-	// If Javadoc is generated, this must be specified in that task too.
-	it.options.encoding = "UTF-8"
-
-	// Minecraft 1.17 (21w19a) upwards uses Java 16.
-	it.options.release = 16
+	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
+	it.options.release = 17
 }
 
 java {
@@ -67,13 +58,7 @@ jar {
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
-			// add all the jars that should be included when publishing to maven
-			artifact(remapJar) {
-				builtBy remapJar
-			}
-			artifact(sourcesJar) {
-				builtBy remapSourcesJar
-			}
+			from components.java
 		}
 	}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties from the Fabric insaller
-minecraft_version=1.18-pre6
-yarn_mappings=1.18-pre6+build.1
+minecraft_version=1.18-rc1
+yarn_mappings=1.18-rc1+build.1
 loader_version=0.12.5
 
 # Mod Properties
@@ -12,4 +12,4 @@ maven_group = com.logicalgeekboy.logical_zoom
 archives_base_name = logical_zoom
 
 # Fabric API version
-fabric_version=0.42.9+1.18
+fabric_version=0.43.1+1.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,15 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-# Fabric Properties
-# check these on https://modmuss50.me/fabric.html
-minecraft_version=1.17.1
-yarn_mappings=1.17.1+build.1
-loader_version=0.11.6
+# Fabric Properties from the Fabric insaller
+minecraft_version=1.18-pre6
+yarn_mappings=1.18-pre6+build.1
+loader_version=0.12.5
 
 # Mod Properties
-mod_version = 0.0.11
+mod_version = 0.0.12
 maven_group = com.logicalgeekboy.logical_zoom
 archives_base_name = logical_zoom
 
-# Dependencies
-# check these on https://modmuss50.me/fabric.html
-fabric_version=0.36.1+1.17
+# Fabric API version
+fabric_version=0.42.9+1.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties from the Fabric insaller
-minecraft_version=1.18-rc1
-yarn_mappings=1.18-rc1+build.1
+minecraft_version=1.18-rc3
+yarn_mappings=1.18-rc3+build.1
 loader_version=0.12.5
 
 # Mod Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties from the Fabric insaller
-minecraft_version=1.18-rc3
-yarn_mappings=1.18-rc3+build.1
+minecraft_version=1.18
+yarn_mappings=1.18+build.1
 loader_version=0.12.5
 
 # Mod Properties

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,9 +30,9 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.11.6",
+    "fabricloader": ">=0.12.5",
     "fabric": "*",
-    "minecraft": "1.17.1"
+    "minecraft": "1.18-beta.6"
   },
   "suggests": {
     "flamingo": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
   "depends": {
     "fabricloader": ">=0.12.5",
     "fabric": "*",
-    "minecraft": "1.18-rc.3"
+    "minecraft": "1.18"
   },
   "suggests": {
     "flamingo": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
   "depends": {
     "fabricloader": ">=0.12.5",
     "fabric": "*",
-    "minecraft": "1.18-rc.1"
+    "minecraft": "1.18-rc.3"
   },
   "suggests": {
     "flamingo": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
   "depends": {
     "fabricloader": ">=0.12.5",
     "fabric": "*",
-    "minecraft": "1.18-beta.6"
+    "minecraft": "1.18-rc.1"
   },
   "suggests": {
     "flamingo": "*"

--- a/src/main/resources/logical_zoom.client-mixins.json
+++ b/src/main/resources/logical_zoom.client-mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "com.logicalgeekboy.logical_zoom.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
   ],
   "client": [


### PR DESCRIPTION
* Update for 1.18 final release
* Update for 1.18-rc3
* Update for 1.18-rc1
* Update for 1.18-pre6
* Update Java to 17

Once 1.18 final is releases, this PR will be updated and merged followed by a release of Logical Zoom for MC 1.18.