### PR TITLE
Replaced jcenter with mavenCentral

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,10 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
+        mavenCentral()
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
For more information see:
* [JFrog Announcement](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)
* [Android/Google Statement](https://developer.android.com/studio/build/jcenter-migration)

Changed the settings.gradle file so that it looks like [the one in the fabric-example-mod](https://github.com/FabricMC/fabric-example-mod/blob/1.19/settings.gradle)