### PR TITLE
Make zoom level the same as OptiFine's

### DIFF
--- a/src/main/java/com/logicalgeekboy/logical_zoom/LogicalZoom.java
+++ b/src/main/java/com/logicalgeekboy/logical_zoom/LogicalZoom.java
@@ -15,7 +15,7 @@ public class LogicalZoom implements ClientModInitializer {
     private static boolean originalSmoothCameraEnabled;
     private static final MinecraftClient mc = MinecraftClient.getInstance();
 
-    public static final double zoomLevel = 0.23;
+    public static final double zoomLevel = 0.25;
 
     @Override
     public void onInitializeClient() {


### PR DESCRIPTION
OptiFine always divides the FOV by 4. This "fixes" the mod so it's the same (unless you do not want this).