### PR TITLE
Axiom Compatibility Issue Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,18 @@ repositories {
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
+
+	exclusiveContent {
+		forRepository {
+			maven {
+				name = "Modrinth"
+				url = "https://api.modrinth.com/maven"
+			}
+		}
+		filter {
+			includeGroup "maven.modrinth"
+		}
+	}
 }
 
 dependencies {
@@ -26,6 +38,8 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+	modCompileOnly "maven.modrinth:axiom:${project.compat_axiom_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,6 @@ fabric_version=0.97.8+1.20.6
 mod_version = 0.0.24
 maven_group = com.logicalgeekboy.logical_zoom
 archives_base_name = logical_zoom
+
+#compatibility
+compat_axiom_version = 2.8.1

--- a/src/main/java/com/logicalgeekboy/logical_zoom/compat/AxiomCompat.java
+++ b/src/main/java/com/logicalgeekboy/logical_zoom/compat/AxiomCompat.java
@@ -1,0 +1,9 @@
+package com.logicalgeekboy.logical_zoom.compat;
+
+import com.moulberry.axiom.editor.EditorUI;
+
+public class AxiomCompat {
+	public static boolean isInEditor() {
+		return EditorUI.isActive();
+	}
+}

--- a/src/main/java/com/logicalgeekboy/logical_zoom/mixin/LogicalZoomMixin.java
+++ b/src/main/java/com/logicalgeekboy/logical_zoom/mixin/LogicalZoomMixin.java
@@ -2,6 +2,7 @@ package com.logicalgeekboy.logical_zoom.mixin;
 
 import com.logicalgeekboy.logical_zoom.LogicalZoom;
 
+import com.logicalgeekboy.logical_zoom.compat.AxiomCompat;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -11,7 +12,6 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
 import net.fabricmc.loader.api.FabricLoader;
-import com.moulberry.axiom.editor.EditorUI;
 
 import net.minecraft.client.render.GameRenderer;
 
@@ -21,7 +21,7 @@ public class LogicalZoomMixin {
 
     @Inject(method = "getFov(Lnet/minecraft/client/render/Camera;FZ)D", at = @At("RETURN"), cancellable = true)
     public void getZoomLevel(CallbackInfoReturnable<Double> callbackInfo) {
-        if(FabricLoader.getInstance().isModLoaded("axiom") && EditorUI.isActive()) {
+        if(FabricLoader.getInstance().isModLoaded("axiom") && AxiomCompat.isInEditor()) {
             return;
         }
 

--- a/src/main/java/com/logicalgeekboy/logical_zoom/mixin/LogicalZoomMixin.java
+++ b/src/main/java/com/logicalgeekboy/logical_zoom/mixin/LogicalZoomMixin.java
@@ -10,6 +10,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
+import net.fabricmc.loader.api.FabricLoader;
+import com.moulberry.axiom.editor.EditorUI;
+
 import net.minecraft.client.render.GameRenderer;
 
 @Environment(EnvType.CLIENT)
@@ -18,6 +21,10 @@ public class LogicalZoomMixin {
 
     @Inject(method = "getFov(Lnet/minecraft/client/render/Camera;FZ)D", at = @At("RETURN"), cancellable = true)
     public void getZoomLevel(CallbackInfoReturnable<Double> callbackInfo) {
+        if(FabricLoader.getInstance().isModLoaded("axiom") && EditorUI.isActive()) {
+            return;
+        }
+
         if(LogicalZoom.isZooming()) {
             double fov = callbackInfo.getReturnValue();
             callbackInfo.setReturnValue(fov * LogicalZoom.zoomLevel);


### PR DESCRIPTION
I made it so that it is no longer possible to zoom whilst being in axioms editor view. I feel the ability to zoom is not necessary there, and sometimes even impossible to work with.
It uses axiom 2.8.1 because that is the latest version on modrinth, but it should work for newer versions (tested it with 3.0.0).